### PR TITLE
More than 1 tag editor per page

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -16,7 +16,7 @@
 		var html_input_field = "<li class=\"tagit-new\"><input class=\"tagit-input\" type=\"text\" /></li>\n";
 		el.html (html_input_field);
 
-		tag_input		= el.children(".tagit-new").children(".tagit-input");
+		var tag_input		= el.children(".tagit-new").children(".tagit-input");
 
 		$(this).click(function(e){
 			if (e.target.tagName == 'A') {


### PR DESCRIPTION
Hi, 

Since the variable, "tag_input" is not declared in the function, it is used under global namespace. This stops us from using 2 different tag editors in the same page. 

Changed it to "var tag_input" as per http://www.javascripttoolbox.com/bestpractices/. 
