### PR TITLE
Change "tag_input" to "var tag_input" to allow multiple tag fields on a single page

### DIFF
--- a/js/tag-it.js
+++ b/js/tag-it.js
@@ -16,7 +16,7 @@
 		var html_input_field = "<li class=\"tagit-new\"><input class=\"tagit-input\" type=\"text\" /></li>\n";
 		el.html (html_input_field);
 
-		tag_input		= el.children(".tagit-new").children(".tagit-input");
+		var tag_input		= el.children(".tagit-new").children(".tagit-input");
 
 		$(this).click(function(e){
 			if (e.target.tagName == 'A') {
@@ -72,7 +72,7 @@
 
 		function is_new (value){
 			var is_new = true;
-			this.tag_input.parents("ul").children(".tagit-choice").each(function(i){
+			tag_input.parents("ul").children(".tagit-choice").each(function(i){
 				n = $(this).children("input").val();
 				if (value == n) {
 					is_new = false;
@@ -87,9 +87,9 @@
 			el += "<a class=\"close\">x</a>\n";
 			el += "<input type=\"hidden\" style=\"display:none;\" value=\""+value+"\" name=\"item[tags][]\">\n";
 			el += "</li>\n";
-			var li_search_tags = this.tag_input.parent();
+			var li_search_tags = tag_input.parent();
 			$(el).insertBefore (li_search_tags);
-			this.tag_input.val("");
+			tag_input.val("");
 		}
 	};
 


### PR DESCRIPTION
Nice work here!

I changed "tag_input" to "var tag_input" and changed instances of this.tag_input to tag_input to fix issues caused by the global declaration when putting more than one of these tag fields on a single page.

Do you think that would cause any issues?

Also - what's an example of a script to read in the tags for a particular tag-it ul?
